### PR TITLE
Patch 1

### DIFF
--- a/action.pl
+++ b/action.pl
@@ -91,8 +91,7 @@ main :-
         format('Covered:~t~f~40|%~n', [CoveredPercent]),
         shield(CoveredPercent, FailedInFilePercent)
     ;   true
-    ),
-    !.
+    ).
 
 shield(Cov, Fail) :-
     setting(runner_os, RunnerOS),

--- a/action.pl
+++ b/action.pl
@@ -103,10 +103,11 @@ shield(Cov, Fail) :-
 
 shield(Cov, Fail, Reply) :-
     setting(gist_id, GistID),
-    GistID \== '',
-    !,
-    shield_files([cov-Cov, fail-Fail], Files),
-    ghapi_update_gist(GistID, json(json([files=Files])), Reply, []).
+    (   GistID == ''
+    ->  true
+    ;   shield_files([cov-Cov, fail-Fail], Files),
+        ghapi_update_gist(GistID, json(json([files=Files])), Reply, [])
+    ).
 
 shield_files(Pairs, json(Files)) :- maplist(shield_file, Pairs, Files).
 

--- a/action.pl
+++ b/action.pl
@@ -34,7 +34,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 :- use_module(library(ordsets),
               [ord_intersect/2, ord_intersection/3, ord_subtract/3]).
 :- use_module(library(prolog_pack), [pack_property/2]).
-:- use_module(library(test_cover), [show_coverage/1]).
+:- use_module(library(prolog_coverage), [show_coverage/1]).
 :- use_module(library(url), [parse_url/2]).
 :- use_module(library(http/http_client), [http_get/3]).
 :- use_module(library(http/json), [atom_json_term/3, json_write_dict/3]).
@@ -163,11 +163,11 @@ cover(Goal, Dir, Covers) :-
 
 cover_subdir(Dir, File-Cover, Rel-Cover) :- subdir(Dir, File, Rel).
 
-cover(Goal, Covers) :- show_coverage(covered(Goal, Covers)).
+cover(Goal, Covers) :- coverage(covered(Goal, Covers), []).
 
 covered(Goal, Covers) :-
     call(Goal),
-    prolog_cover:covered(Succeeded, Failed),
+    prolog_coverage:covered(Succeeded, Failed),
     findall(Cover, file_cover(Succeeded, Failed, Cover), Covers).
 
 %!  file_cover(Succeeded, Failed, FileCover:pair(atom, dict)) is nondet.
@@ -188,7 +188,7 @@ file_cover(File, Succeeded, Failed,
                not_covered:NotCoveredLength,
                failed_in_file:FailedInFileLength
            }) :-
-    findall(Clause, prolog_cover:clause_source(Clause, File, _), InFile0),
+    findall(Clause, prolog_coverage:clause_source(Clause, File, _), InFile0),
     sort(InFile0, InFile),
     (   ord_intersect(InFile, Succeeded)
     ->  true
@@ -216,7 +216,7 @@ file_cover(File, Succeeded, Failed,
 %   coverage percentage.
 
 clean(Clauses, Length) :-
-    prolog_cover:clean_set(Clauses, CleanClauses0),
+    prolog_coverage:clean_set(Clauses, CleanClauses0),
     exclude(is_dirty, CleanClauses0, CleanClauses),
     length(CleanClauses, Length).
 
@@ -226,7 +226,7 @@ is_dirty(Clause) :-
 
 dirty_predicate(user:_/_) :- !.
 dirty_predicate(plunit:_/_) :- !.
-dirty_predicate(prolog_cover:_/_) :- !.
+dirty_predicate(prolog_coverage:_/_) :- !.
 dirty_predicate(_:'unit test'/_).
 
 %!  subdir(+Dir, +File, -Rel) is semidet.

--- a/action.pl
+++ b/action.pl
@@ -91,7 +91,8 @@ main :-
         format('Covered:~t~f~40|%~n', [CoveredPercent]),
         shield(CoveredPercent, FailedInFilePercent)
     ;   true
-    ).
+    ),
+    !.
 
 shield(Cov, Fail) :-
     setting(runner_os, RunnerOS),

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       run: swipl -t "pack_install(., [interactive(false), link(false)])"
       shell: bash
     - name: Run tests with coverage
-      run: swipl -s "${{ github.action_path }}/action.pl"
+      run: swipl -g "debug(_>'/proc/self/fd/2')" -g debugging -s "${{ github.action_path }}/action.pl"
       shell: bash
 branding:
   icon: 'check-circle'

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ runs:
     - name: Run tests with coverage
       run: swipl -g "debug(_>'/proc/self/fd/2')" -g debugging -s "${{ github.action_path }}/action.pl"
       shell: bash
+      env:
+        COVFAIL_GISTID: ${{ secrets.COVFAIL_GISTID }}
+        GHAPI_PAT: ${{ secrets.GHAPI_PAT }}
 branding:
   icon: 'check-circle'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       run: swipl -t "pack_install(., [interactive(false), link(false)])"
       shell: bash
     - name: Run tests with coverage
-      run: swipl -g "debug(_>'/proc/self/fd/2')" -g debugging -s "${{ github.action_path }}/action.pl"
+      run: swipl -g "debug(_)" -g debugging -s "${{ github.action_path }}/action.pl"
       shell: bash
 branding:
   icon: 'check-circle'

--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,6 @@ runs:
     - name: Run tests with coverage
       run: swipl -g "debug(_>'/proc/self/fd/2')" -g debugging -s "${{ github.action_path }}/action.pl"
       shell: bash
-      env:
-        COVFAIL_GISTID: ${{ secrets.COVFAIL_GISTID }}
-        GHAPI_PAT: ${{ secrets.GHAPI_PAT }}
 branding:
   icon: 'check-circle'
   color: 'green'


### PR DESCRIPTION
Fixed for SWI-Prolog 9.3.18 development release. Modules `test_cover` and `prolog_cover` refactored to `prolog_coverage`.

This patch also avoids `main` failure if the runner cannot find a Gist ID for the shield update. It also enables "debug" messages to help with workflow diagnosis.